### PR TITLE
Refactor: Rename FitLog to Peak Zenit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fitlog-app",
+  "name": "peak-zenit-app",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/src/app/(application)/layout.tsx
+++ b/src/app/(application)/layout.tsx
@@ -78,7 +78,7 @@ export default function ApplicationLayout({
     const drawerContent = (
         <Box onClick={handleDrawerToggle} sx={{ textAlign: 'center' }}>
             <Typography variant="h6" sx={{ my: 2 }}>
-                FitLog
+                Peak Zenit
             </Typography>
             <Divider />
             <List>
@@ -141,7 +141,7 @@ export default function ApplicationLayout({
                         <MenuIcon />
                     </IconButton>
                     <Typography variant="h6" noWrap component="div" sx={{ flexGrow: 1 }}>
-                        FitLog
+                        Peak Zenit
                     </Typography>
                     {/* You can add other AppBar items here, like a user avatar or name */}
                 </Toolbar>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,7 +16,7 @@ const roboto = Roboto({
 });
 
 export const metadata: Metadata = {
-    title: "FitLog App",
+    title: "Peak Zenit App",
     description: "Your AI-Powered Fitness Application",
 };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -38,7 +38,7 @@ export default function HomePage() {
       >
         <CircularProgress />
         <Typography variant="h6" sx={{ mt: 2 }}>
-          Loading FitLog...
+          Loading Peak Zenit...
         </Typography>
       </Container>
   );


### PR DESCRIPTION
I replaced all occurrences of the name 'FitLog' and its variations (e.g., 'fitlog-app') with 'Peak Zenit' and 'peak-zenit-app' respectively throughout the codebase.

Changes include:
- Updated application name in package.json.
- Updated page titles and metadata.
- Updated UI text elements in application layouts and pages.